### PR TITLE
マッチング相手の年齢指定削除、異性のカード表示対応

### DIFF
--- a/DoryInClub/API/Service.swift
+++ b/DoryInClub/API/Service.swift
@@ -24,9 +24,9 @@ struct Service {
         var users = [User]()
     
         let query = COLLECTION_USERS
-            .whereField("age", isGreaterThanOrEqualTo: user.minSeekingAge)
-            .whereField("age", isLessThanOrEqualTo: user.maxSeekingAge)
-//            .whereField("gender", isEqualTo: "男")
+//            .whereField("age", isGreaterThanOrEqualTo: user.minSeekingAge)
+//            .whereField("age", isLessThanOrEqualTo: user.maxSeekingAge)
+            .whereField("gender", isNotEqualTo: user.gender)
         
         fetchSwipes { (swipedUserIDs) in
             query.getDocuments { (snapShot, error) in

--- a/DoryInClub/Controller/SettingsViewController.swift
+++ b/DoryInClub/Controller/SettingsViewController.swift
@@ -156,7 +156,8 @@ extension SettingsViewController {
     
     override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         guard let section = SettingsSections(rawValue: indexPath.section) else { return 0 }
-        return section == .ageRange ? 96 : 44
+//        return section == .ageRange ? 96 : 44
+        return 44
     }
 
 }
@@ -185,13 +186,13 @@ extension SettingsViewController: UIImagePickerControllerDelegate, UINavigationC
 
 
 extension SettingsViewController: SettingsCellDelegate {
-    func settingsCell(_ cell: SettingCell, wantsToUpdateAgeRangeWith sender: UISlider) {
-        if sender == cell.minAgeSlider {
-            user.minSeekingAge = Int(sender.value)
-        } else {
-            user.maxSeekingAge = Int(sender.value)
-        }
-    }
+//    func settingsCell(_ cell: SettingCell, wantsToUpdateAgeRangeWith sender: UISlider) {
+//        if sender == cell.minAgeSlider {
+//            user.minSeekingAge = Int(sender.value)
+//        } else {
+//            user.maxSeekingAge = Int(sender.value)
+//        }
+//    }
     
     func settingsCell(_ cell: SettingCell, wantsToUpdateUserWith value: String,
                       for section: SettingsSections) {
@@ -209,8 +210,8 @@ extension SettingsViewController: SettingsCellDelegate {
             user.bio = value
         case .club:
             user.club = value
-        case .ageRange:
-            break
+//        case .ageRange:
+//            break
         }
         
         print("ユーザー\(user)")

--- a/DoryInClub/View/Settings/SettingCell.swift
+++ b/DoryInClub/View/Settings/SettingCell.swift
@@ -11,7 +11,7 @@ protocol SettingsCellDelegate: class {
     func settingsCell(_ cell: SettingCell, wantsToUpdateUserWith value: String,
                       for section: SettingsSections)
     
-    func settingsCell(_ cell: SettingCell, wantsToUpdateAgeRangeWith sender: UISlider)
+//    func settingsCell(_ cell: SettingCell, wantsToUpdateAgeRangeWith sender: UISlider)
 }
 
 class SettingCell: UITableViewCell {
@@ -85,8 +85,8 @@ class SettingCell: UITableViewCell {
     let minAgeLabel = UILabel()
     let maxAgeLabel = UILabel()
     
-    lazy var minAgeSlider = createAgeRangeSlider()
-    lazy var maxAgeSlider = createAgeRangeSlider()
+//    lazy var minAgeSlider = createAgeRangeSlider()
+//    lazy var maxAgeSlider = createAgeRangeSlider()
     
     // MARK: - Lifecycle
     
@@ -104,19 +104,19 @@ class SettingCell: UITableViewCell {
         contentView.addSubview(clubTextField)
         clubTextField.fillSuperview()
         
-        let minStack = UIStackView(arrangedSubviews: [minAgeLabel, minAgeSlider])
-        minStack.spacing = 24
+//        let minStack = UIStackView(arrangedSubviews: [minAgeLabel, minAgeSlider])
+//        minStack.spacing = 24
+//
+//        let maxStack = UIStackView(arrangedSubviews: [maxAgeLabel, maxAgeSlider])
+//        maxStack.spacing = 24
+//
+//        sliderStack = UIStackView(arrangedSubviews: [minStack, maxStack])
+//        sliderStack.axis = .vertical
+//        sliderStack.spacing = 16
         
-        let maxStack = UIStackView(arrangedSubviews: [maxAgeLabel, maxAgeSlider])
-        maxStack.spacing = 24
-        
-        sliderStack = UIStackView(arrangedSubviews: [minStack, maxStack])
-        sliderStack.axis = .vertical
-        sliderStack.spacing = 16
-        
-        contentView.addSubview(sliderStack)
-        sliderStack.centerY(inView: self)
-        sliderStack.anchor(left: leftAnchor, right: rightAnchor, paddingLeft: 24, paddingRight: 24)
+//        contentView.addSubview(sliderStack)
+//        sliderStack.centerY(inView: self)
+//        sliderStack.anchor(left: leftAnchor, right: rightAnchor, paddingLeft: 24, paddingRight: 24)
         
     }
     
@@ -131,15 +131,15 @@ class SettingCell: UITableViewCell {
         delegate?.settingsCell(self, wantsToUpdateUserWith: value, for: viewModel.sections)
     }
     
-    @objc func handleAgeRangeChange(sender: UISlider) {
-        if sender == minAgeSlider {
-            minAgeLabel.text = viewModel.minAgeLabelText(forValue: sender.value)
-        } else {
-            maxAgeLabel.text = viewModel.maxAgeLabelText(forValue: sender.value)
-        }
-        
-        delegate?.settingsCell(self, wantsToUpdateAgeRangeWith: sender)
-    }
+//    @objc func handleAgeRangeChange(sender: UISlider) {
+//        if sender == minAgeSlider {
+//            minAgeLabel.text = viewModel.minAgeLabelText(forValue: sender.value)
+//        } else {
+//            maxAgeLabel.text = viewModel.maxAgeLabelText(forValue: sender.value)
+//        }
+//
+//        delegate?.settingsCell(self, wantsToUpdateAgeRangeWith: sender)
+//    }
     
     @objc func genderDone() {
         genderTextField.endEditing(true)
@@ -155,7 +155,7 @@ class SettingCell: UITableViewCell {
     
     func configure() {
         inputTextField.isHidden = viewModel.shouldHideInputTextField
-        sliderStack.isHidden = viewModel.shouldHideSlider
+//        sliderStack.isHidden = viewModel.shouldHideSlider
         genderTextField.isHidden = viewModel.shouldHideGenderPicker
         clubTextField.isHidden = viewModel.shouldHideClubPicker
         
@@ -168,21 +168,21 @@ class SettingCell: UITableViewCell {
         clubTextField.placeholder = viewModel.placeholderText
         clubTextField.text = viewModel.value
         
-        minAgeLabel.text = viewModel.minAgeLabelText(forValue: viewModel.minAgeSliderValue)
-        maxAgeLabel.text = viewModel.maxAgeLabelText(forValue: viewModel.maxAgeSliderValue)
-
-        minAgeSlider.setValue(viewModel.minAgeSliderValue, animated: true)
-        maxAgeSlider.setValue(viewModel.maxAgeSliderValue, animated: true)
+//        minAgeLabel.text = viewModel.minAgeLabelText(forValue: viewModel.minAgeSliderValue)
+//        maxAgeLabel.text = viewModel.maxAgeLabelText(forValue: viewModel.maxAgeSliderValue)
+//
+//        minAgeSlider.setValue(viewModel.minAgeSliderValue, animated: true)
+//        maxAgeSlider.setValue(viewModel.maxAgeSliderValue, animated: true)
 
     }
     
-    func createAgeRangeSlider() -> UISlider {
-        let slider = UISlider()
-        slider.minimumValue = 18
-        slider.maximumValue = 60
-        slider.addTarget(self, action: #selector(handleAgeRangeChange), for: .valueChanged)
-        return slider
-    }
+//    func createAgeRangeSlider() -> UISlider {
+//        let slider = UISlider()
+//        slider.minimumValue = 18
+//        slider.maximumValue = 60
+//        slider.addTarget(self, action: #selector(handleAgeRangeChange), for: .valueChanged)
+//        return slider
+//    }
     
     func createPicker() {
         // ピッカー設定

--- a/DoryInClub/ViewModel/SettingsViewModel.swift
+++ b/DoryInClub/ViewModel/SettingsViewModel.swift
@@ -14,7 +14,7 @@ enum SettingsSections: Int, CaseIterable {
     case bio
     case gender
     case club
-    case ageRange
+//    case ageRange
     
     var discription: String {
         switch self {
@@ -24,7 +24,7 @@ enum SettingsSections: Int, CaseIterable {
         case .bio: return "Bio"
         case .gender: return "man or female"
         case .club: return "favorite or being club"
-        case .ageRange: return "Seeking Age Range"
+//        case .ageRange: return "Seeking Age Range"
         }
     }
 }
@@ -38,7 +38,7 @@ struct SettingsViewModel {
     var value: String?
     
     var shouldHideInputTextField: Bool {
-        return sections == .ageRange || sections == .gender || sections == .club
+        return sections == .gender || sections == .club
     }
     
     var shouldHideGenderPicker: Bool {
@@ -49,9 +49,9 @@ struct SettingsViewModel {
         return sections != .club
     }
     
-    var shouldHideSlider: Bool {
-        return sections != .ageRange
-    }
+//    var shouldHideSlider: Bool {
+//        return sections != .ageRange
+//    }
     
     var minAgeSliderValue: Float {
         return Float(user.minSeekingAge)
@@ -90,8 +90,8 @@ struct SettingsViewModel {
             value = user.gender
         case .club:
             value = user.club
-        case .ageRange:
-            break
+//        case .ageRange:
+//            break
         }
     }
     


### PR DESCRIPTION
上記の対応ではないですが、もしお時間あれば以下質問対応お願いいたします。
コード見ないとわかりにくいと思ったのでこちらで質問させていただきます。
また、そちらのコードレビューもしていただけると幸いです。
（ハードコーディングはのちにまとめて修正いたします。）

1.質問の概要
未読の際はViewを表示し、既読の際はViewを非表示にする処理をしている箇所があるが、
その切り替わり(Viewの表示→非表示)が画面遷移をした後でないと反映されない。
こちらを即時反映させたい。

2.前提となる情報
アーキテクチャはMVVMで上記の処理はViewの部分で実装している
Firebaseに isRead: true(false) コレクションを作成し、そちらを取得し反映している
Viewで上記を取得し、conversatiionのdidSet内で反映している。

該当箇所
Service.swift（API）
Message.swift（Model）
UsersCell.swift（View）
UsersViewModel.swift（ViewModel）
MessagesViewController.swift（Controller）

3.期待する挙動
画面をまたがず、上記の処理を反映させたい。

4.発生するエラーや意図しない挙動の説明
画面遷移をした後でないと反映されない。