### PR TITLE
未読既読の即時反映->失敗

### DIFF
--- a/DoryInClub/API/Service.swift
+++ b/DoryInClub/API/Service.swift
@@ -141,6 +141,7 @@ struct Service {
                 if direction == currentUserUid {
                     completion(read)
                 }
+                completion(true)
 //                if read == false && direction == currentUserUid {
 //                    completion(read)
 //                }

--- a/DoryInClub/API/Service.swift
+++ b/DoryInClub/API/Service.swift
@@ -130,7 +130,7 @@ struct Service {
             }
     }
     
-    static func checkRead(forChatWith user: User, completion: @escaping(Bool) -> Void) {
+    static func checkIsRead(forChatWith user: User, completion: @escaping(Bool) -> Void) {
         guard let currentUserUid = Auth.auth().currentUser?.uid else { return }
         
         COLLECTION_MATCHES_MESSAGES.document(currentUserUid).collection("recent-messages")
@@ -138,9 +138,12 @@ struct Service {
                 guard let data = snapshot else { return }
                 guard let read = data["isRead"] as? Bool else { return }
                 guard let direction = data["toId"] as? String else { return }
-                if read == false && direction == currentUserUid {
+                if direction == currentUserUid {
                     completion(read)
                 }
+//                if read == false && direction == currentUserUid {
+//                    completion(read)
+//                }
             }
     }
     

--- a/DoryInClub/Controller/MessagesViewController.swift
+++ b/DoryInClub/Controller/MessagesViewController.swift
@@ -17,8 +17,7 @@ class MessagesViewController: UITableViewController {
     private let headerView = MatchHeader()
     private var conversations = [Conversation]()
     private var conversationsDictionary = [String: Conversation]()
-    private var isReadArray = [Bool]()
-    let cell = UsersCell()
+    private var isReadList = [Bool]()
     
     // MARK: - Lifecycle
     
@@ -65,14 +64,10 @@ class MessagesViewController: UITableViewController {
                 self.conversationsDictionary[message.chatPartnerId] = conversation
                 //ここに処理を書く
                 Service.checkIsRead(forChatWith: conversation.user) { (isRead) in
-                    self.isReadArray.append(isRead)
-                    print("=====\(self.isReadArray)")
-                    print("呼ばれる順番3")
-                    //これでは反映されない
-                    self.cell.unreadView.isHidden = isRead
-                    //falseにはなっている
-                    print("======\(self.cell.unreadView.isHidden)")
-                    
+                    self.isReadList.append(isRead)
+                    self.tableView.reloadData()
+                    print("ここでAPI通信")
+                    print(self.isReadList)
                 }
             }
             self.showLoader(false)
@@ -135,8 +130,9 @@ extension MessagesViewController {
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: reuseIdentifier, for: indexPath) as! UsersCell
         cell.conversation = conversations[indexPath.row]
-        print("=====\(isReadArray)")
-//        cell.unreadView.isHidden = isReadArray[indexPath.row]
+        if isReadList.count > indexPath.row {
+            cell.isRead = isReadList[indexPath.row]
+        }
         print("呼ばれる順番2")
         return cell
     }

--- a/DoryInClub/Controller/MessagesViewController.swift
+++ b/DoryInClub/Controller/MessagesViewController.swift
@@ -17,7 +17,8 @@ class MessagesViewController: UITableViewController {
     private let headerView = MatchHeader()
     private var conversations = [Conversation]()
     private var conversationsDictionary = [String: Conversation]()
-    private var cell = UsersCell()
+    private var isReadArray = [Bool]()
+    let cell = UsersCell()
     
     // MARK: - Lifecycle
     
@@ -31,12 +32,11 @@ class MessagesViewController: UITableViewController {
         configureNavigationBar()
         fetchMatches()
         fetchConversations()
-        fetchCheckIsRead(forUser: user)
     }
     
     override func viewWillAppear(_ animated: Bool) {
         configureNavigationBar()
-        fetchCheckIsRead(forUser: user)
+        fetchConversations()
     }
     
     required init?(coder: NSCoder) {
@@ -63,6 +63,17 @@ class MessagesViewController: UITableViewController {
             conversations.forEach { (conversation) in
                 let message = conversation.message
                 self.conversationsDictionary[message.chatPartnerId] = conversation
+                //ここに処理を書く
+                Service.checkIsRead(forChatWith: conversation.user) { (isRead) in
+                    self.isReadArray.append(isRead)
+                    print("=====\(self.isReadArray)")
+                    print("呼ばれる順番3")
+                    //これでは反映されない
+                    self.cell.unreadView.isHidden = isRead
+                    //falseにはなっている
+                    print("======\(self.cell.unreadView.isHidden)")
+                    
+                }
             }
             self.showLoader(false)
             self.conversations = Array(self.conversationsDictionary.values)
@@ -72,12 +83,6 @@ class MessagesViewController: UITableViewController {
     
     func updateRead(forUser user: User) {
         Service.updateRead(wantToCheckWith: user)
-    }
-    
-    func fetchCheckIsRead(forUser user: User) {
-        Service.checkRead(forChatWith: user) { (isRead) in
-            self.cell.unreadView.isHidden = isRead
-        }
     }
 
     // MARK: - Helpers
@@ -130,7 +135,9 @@ extension MessagesViewController {
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: reuseIdentifier, for: indexPath) as! UsersCell
         cell.conversation = conversations[indexPath.row]
-        fetchCheckIsRead(forUser: user)
+        print("=====\(isReadArray)")
+//        cell.unreadView.isHidden = isReadArray[indexPath.row]
+        print("呼ばれる順番2")
         return cell
     }
 }
@@ -179,7 +186,7 @@ extension MessagesViewController: MatchHeaderDelegate {
 
 extension MessagesViewController: UsersCellDelegate {
     func usersCell(_ cell: UsersCell, wantsToCheck user: User) {
-        fetchCheckIsRead(forUser: user)
+        print("===")
     }
 }
 

--- a/DoryInClub/Controller/MessagesViewController.swift
+++ b/DoryInClub/Controller/MessagesViewController.swift
@@ -17,6 +17,7 @@ class MessagesViewController: UITableViewController {
     private let headerView = MatchHeader()
     private var conversations = [Conversation]()
     private var conversationsDictionary = [String: Conversation]()
+    private var cell = UsersCell()
     
     // MARK: - Lifecycle
     
@@ -27,13 +28,15 @@ class MessagesViewController: UITableViewController {
     
     override func viewDidLoad() {
         configureTableView()
-//        configureNavigationBar()
+        configureNavigationBar()
         fetchMatches()
         fetchConversations()
+        fetchCheckIsRead(forUser: user)
     }
     
     override func viewWillAppear(_ animated: Bool) {
         configureNavigationBar()
+        fetchCheckIsRead(forUser: user)
     }
     
     required init?(coder: NSCoder) {
@@ -69,6 +72,12 @@ class MessagesViewController: UITableViewController {
     
     func updateRead(forUser user: User) {
         Service.updateRead(wantToCheckWith: user)
+    }
+    
+    func fetchCheckIsRead(forUser user: User) {
+        Service.checkRead(forChatWith: user) { (isRead) in
+            self.cell.unreadView.isHidden = isRead
+        }
     }
 
     // MARK: - Helpers
@@ -121,6 +130,7 @@ extension MessagesViewController {
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: reuseIdentifier, for: indexPath) as! UsersCell
         cell.conversation = conversations[indexPath.row]
+        fetchCheckIsRead(forUser: user)
         return cell
     }
 }
@@ -164,3 +174,12 @@ extension MessagesViewController: MatchHeaderDelegate {
     }
 
 }
+
+// MARK: - UsersCellDelegate
+
+extension MessagesViewController: UsersCellDelegate {
+    func usersCell(_ cell: UsersCell, wantsToCheck user: User) {
+        fetchCheckIsRead(forUser: user)
+    }
+}
+

--- a/DoryInClub/Controller/MessagesViewController.swift
+++ b/DoryInClub/Controller/MessagesViewController.swift
@@ -18,6 +18,7 @@ class MessagesViewController: UITableViewController {
     private var conversations = [Conversation]()
     private var conversationsDictionary = [String: Conversation]()
     private var isReadList = [Bool]()
+    private var isRead = true
     
     // MARK: - Lifecycle
     
@@ -66,8 +67,7 @@ class MessagesViewController: UITableViewController {
                 Service.checkIsRead(forChatWith: conversation.user) { (isRead) in
                     self.isReadList.append(isRead)
                     self.tableView.reloadData()
-                    print("ここでAPI通信")
-                    print(self.isReadList)
+                    print("ここでAPI通信\(self.isReadList)")
                 }
             }
             self.showLoader(false)
@@ -132,8 +132,9 @@ extension MessagesViewController {
         cell.conversation = conversations[indexPath.row]
         if isReadList.count > indexPath.row {
             cell.isRead = isReadList[indexPath.row]
+            print("呼ばれる順番2、値を渡す＝\(isReadList[indexPath.row])")
+            cell.configure()
         }
-        print("呼ばれる順番2")
         return cell
     }
 }

--- a/DoryInClub/View/Message/UsersCell.swift
+++ b/DoryInClub/View/Message/UsersCell.swift
@@ -7,6 +7,10 @@
 
 import UIKit
 
+protocol UsersCellDelegate: class {
+    func usersCell(_ cell: UsersCell, wantsToCheck user: User)
+}
+
 class UsersCell: UITableViewCell {
     
     // MARK: - Propaties
@@ -44,7 +48,7 @@ class UsersCell: UITableViewCell {
         return label
     }()
     
-    private let unreadView: UIView = {
+    let unreadView: UIView = {
         let view = UIView()
         view.clipsToBounds = true
         view.backgroundColor = .systemPink
@@ -90,12 +94,12 @@ class UsersCell: UITableViewCell {
     }
     
     // MARK: -API
-    func checkRead() {
-        guard let user = conversation?.user else { return }
-        Service.checkRead(forChatWith: user) { (isRead) in
-            self.unreadView.isHidden = isRead
-        }
-    }
+//    func checkRead() {
+//        guard let user = conversation?.user else { return }
+//        Service.checkRead(forChatWith: user) { (isRead) in
+//            self.unreadView.isHidden = isRead
+//        }
+//    }
     
     // MARK: - Helper
     func configure() {
@@ -108,7 +112,7 @@ class UsersCell: UITableViewCell {
         timestampLabel.text = viewModel.timestamp
         profileImageView.sd_setImage(with: viewModel.profileImageUrl)
         
-        checkRead()
+//        checkRead()
     }
 
     

--- a/DoryInClub/View/Message/UsersCell.swift
+++ b/DoryInClub/View/Message/UsersCell.swift
@@ -94,12 +94,7 @@ class UsersCell: UITableViewCell {
     }
     
     // MARK: -API
-//    func checkRead() {
-//        guard let user = conversation?.user else { return }
-//        Service.checkRead(forChatWith: user) { (isRead) in
-//            self.unreadView.isHidden = isRead
-//        }
-//    }
+
     
     // MARK: - Helper
     func configure() {
@@ -111,8 +106,9 @@ class UsersCell: UITableViewCell {
         
         timestampLabel.text = viewModel.timestamp
         profileImageView.sd_setImage(with: viewModel.profileImageUrl)
-        
-//        checkRead()
+                
+        print("呼ばれる順番1")
+    
     }
 
     

--- a/DoryInClub/View/Message/UsersCell.swift
+++ b/DoryInClub/View/Message/UsersCell.swift
@@ -19,6 +19,8 @@ class UsersCell: UITableViewCell {
         didSet { configure() }
     }
     
+    var isRead: Bool = true
+    
     private let profileImageView: UIImageView = {
         let iv = UIImageView()
         iv.backgroundColor = .lightGray
@@ -85,7 +87,6 @@ class UsersCell: UITableViewCell {
         unreadView.layer.cornerRadius = 20 / 2
         unreadView.anchor(left: leftAnchor, paddingLeft: 70)
         unreadView.centerY(inView: self)
-        unreadView.isHidden = true
 
     }
     
@@ -108,6 +109,8 @@ class UsersCell: UITableViewCell {
         profileImageView.sd_setImage(with: viewModel.profileImageUrl)
                 
         print("呼ばれる順番1")
+        print(isRead)
+        unreadView.isHidden = isRead
     
     }
 

--- a/DoryInClub/View/Message/UsersCell.swift
+++ b/DoryInClub/View/Message/UsersCell.swift
@@ -108,8 +108,7 @@ class UsersCell: UITableViewCell {
         timestampLabel.text = viewModel.timestamp
         profileImageView.sd_setImage(with: viewModel.profileImageUrl)
                 
-        print("呼ばれる順番1")
-        print(isRead)
+        print("呼ばれる順番1、反映されるのは\(isRead)")
         unreadView.isHidden = isRead
     
     }


### PR DESCRIPTION
確認、質問対応お願いいたします。
お時間ない中大変申し訳ありません。

1.質問の概要
未読の際はViewを表示し、既読の際はViewを非表示にする処理をしている箇所があるが、
その切り替わり(Viewの表示→非表示)が画面遷移をした後でないと反映されない。
こちらを即時反映させたい。
そのため、判別の処理をViewでなくControllerで行い、
viewWillAppear内でメソッドを記述することを考えたが、そちらが反映されない

2.前提となる情報
アーキテクチャはMVVM。
未読、既読の判別はtableViewのcellがタップされたか否か。
Firebaseに isRead: true(false) コレクションを作成し、そちらを取得し反映している

Viewで上記を判別し、conversatiionのdidSet内で反映していたが、問題解決のため、
Controllerで判別し、viewWillAppear内にメソッドを記述したところ反映されない。

3.期待する挙動
判別の結果が反映され、画面遷移をまたがずして即時反映されること

4.発生するエラーや意図しない挙動の説明
デバックしてみたところ、改修後は、API取得の際、クロージャーの処理が呼ばれていないことがわかった。
