### PR TITLE
タップしたセルを削除する対応

### DIFF
--- a/DoryInClub/API/Service.swift
+++ b/DoryInClub/API/Service.swift
@@ -119,16 +119,16 @@ struct Service {
         
     }
     
-    static func checkTouch(forMatches uid: String, completion: @escaping(Bool) -> Void) {
-        guard let currentUserUid = Auth.auth().currentUser?.uid else { return }
-        
-        COLLECTION_MATCHES_MESSAGES.document(currentUserUid).collection("matches")
-            .document(uid).getDocument { (snapshot, error) in
-                guard let data = snapshot else { return }
-                guard let read = data["isTouch"] as? Bool else { return }
-                completion(read)
-            }
-    }
+//    static func checkTouch(forMatches uid: String, completion: @escaping(Bool) -> Void) {
+//        guard let currentUserUid = Auth.auth().currentUser?.uid else { return }
+//        
+//        COLLECTION_MATCHES_MESSAGES.document(currentUserUid).collection("matches")
+//            .document(uid).getDocument { (snapshot, error) in
+//                guard let data = snapshot else { return }
+//                guard let read = data["isTouch"] as? Bool else { return }
+//                completion(read)
+//            }
+//    }
     
     static func checkRead(forChatWith user: User, completion: @escaping(Bool) -> Void) {
         guard let currentUserUid = Auth.auth().currentUser?.uid else { return }

--- a/DoryInClub/API/Service.swift
+++ b/DoryInClub/API/Service.swift
@@ -249,11 +249,11 @@ struct Service {
         
     }
     
-    static func updateTouch(forMatches uid: String) {
-        guard let currentUserUid = Auth.auth().currentUser?.uid else { return }
-        COLLECTION_MATCHES_MESSAGES.document(currentUserUid).collection("matches")
-            .document(uid).updateData(["isTouch": true])
-    }
+//    static func updateTouch(forMatches uid: String) {
+//        guard let currentUserUid = Auth.auth().currentUser?.uid else { return }
+//        COLLECTION_MATCHES_MESSAGES.document(currentUserUid).collection("matches")
+//            .document(uid).updateData(["isTouch": true])
+//    }
     
     static func updateRead(wantToCheckWith user: User) {
         guard let currentUserUid = Auth.auth().currentUser?.uid else { return }

--- a/DoryInClub/Model/Match.swift
+++ b/DoryInClub/Model/Match.swift
@@ -11,13 +11,13 @@ struct Match {
     let name: String
     let profileImageUrl: String
     let uid: String
-    let isTouch: Bool
+//    let isTouch: Bool
     
     init(dictionary: [String: Any]) {
         self.name = dictionary["name"] as? String ?? ""
         self.profileImageUrl = dictionary["profileImageUrl"] as? String ?? ""
         self.uid = dictionary["uid"] as? String ?? ""
-        self.isTouch = dictionary["isTouch"] as? Bool ?? false
+//        self.isTouch = dictionary["isTouch"] as? Bool ?? false
 
     }
 }

--- a/DoryInClub/View/Message/MatchCell.swift
+++ b/DoryInClub/View/Message/MatchCell.swift
@@ -15,7 +15,7 @@ class MatchCell: UICollectionViewCell {
         didSet {
             userNameLabel.text = viewModel.nameText
             profileImageView.sd_setImage(with: viewModel.profileImageUrl)
-            checkTouch()
+//            checkTouch()
         }
     }
     
@@ -67,7 +67,7 @@ class MatchCell: UICollectionViewCell {
         unreadView.layer.cornerRadius = 20 / 2
         unreadView.centerY(inView: profileImageView)
         unreadView.anchor(right: rightAnchor, paddingRight: 0)
-        unreadView.isHidden = true
+//        unreadView.isHidden = true
 
     }
     
@@ -76,11 +76,11 @@ class MatchCell: UICollectionViewCell {
     }
     
     // MARK: -API
-    func checkTouch() {
-        Service.checkTouch(forMatches: viewModel.uid) { (touch) in
-            self.unreadView.isHidden = touch
-        }
-    }
+//    func checkTouch() {
+//        Service.checkTouch(forMatches: viewModel.uid) { (touch) in
+//            self.unreadView.isHidden = touch
+//        }
+//    }
 
     
     

--- a/DoryInClub/View/Message/MatchHeader.swift
+++ b/DoryInClub/View/Message/MatchHeader.swift
@@ -89,6 +89,7 @@ extension MatchHeader: UICollectionViewDelegate {
         //最初false見たらtrue
         updateTouch(wantsToUpdate: uid)
         delegate?.matchHeader(self, wantsToStartChatWith: uid)
+        self.matches.remove(at: indexPath.row)
     }
 }
 

--- a/DoryInClub/View/Message/MatchHeader.swift
+++ b/DoryInClub/View/Message/MatchHeader.swift
@@ -57,10 +57,6 @@ class MatchHeader: UICollectionReusableView {
         fatalError("init(coder:) has not been implemented")
     }
     
-    // MARK: -API
-    func updateTouch(wantsToUpdate uid: String) {
-        Service.updateTouch(forMatches: uid)
-    }
 
 }
 
@@ -86,8 +82,6 @@ extension MatchHeader: UICollectionViewDataSource {
 extension MatchHeader: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let uid = matches[indexPath.row].uid
-        //最初false見たらtrue
-        updateTouch(wantsToUpdate: uid)
         delegate?.matchHeader(self, wantsToStartChatWith: uid)
         self.matches.remove(at: indexPath.row)
     }


### PR DESCRIPTION
@yamataku29 
セルをタップした際、そのセルを削除する、といった実装です。

期待値通りセルは削除されるのですが、ここで一つ問題が生じています。
1.質問の概要

collectionViewのセルをタップした場合そのセルを削除し、
その状態（ex.セルが3つ→セルが2つ）を保持したい

2.前提となる情報
didSelectItemAt内でself.matches.remove(at: indexPath.row)を行って削除
しかし、以下のようにしてあるため、reloadされて削除が保持されていないと予想している。
    var matches = [Match]() {
        didSet { collectionView.reloadData() }
    }

3.期待する挙動
その削除した状態が保持されること

4.発生するエラーや意図しない挙動の説明
タップした後削除はされるが、再びその画面を開くと削除が保持されない
