### PR TITLE
セルの削除

### DIFF
--- a/DoryInClub/API/Service.swift
+++ b/DoryInClub/API/Service.swift
@@ -184,6 +184,14 @@ struct Service {
         
     }
     
+    static func updateMatch(matchedUser: User) {
+        guard let currentUserUid = Auth.auth().currentUser?.uid else { return }
+        COLLECTION_MATCHES_MESSAGES.document(currentUserUid)
+            .collection("matches").document(matchedUser.uid).delete()
+        COLLECTION_MATCHES_MESSAGES.document(matchedUser.uid)
+            .collection("matches").document(currentUserUid).delete()
+    }
+    
     static func uploadMessage(_ message: String, to user: User, completion: ((Error?) -> Void)?) {
         guard let currentUid = Auth.auth().currentUser?.uid else { return }
         

--- a/DoryInClub/Controller/ChatViewController.swift
+++ b/DoryInClub/Controller/ChatViewController.swift
@@ -180,11 +180,11 @@ extension ChatViewController: CustomInputAccessoryViewDelagate {
         
         Service.uploadMessage(message, to: user) { (error) in
             if let error = error {
-                print("ああああ\(error)")
+                print("エラー、内容＝\(error)")
                 return
             }
-            
             inputView.clearMessageText()
+            Service.updateMatch(matchedUser: self.user)
         }
     }
 }


### PR DESCRIPTION
@yamataku29 
マッチした相手と最初にメッセージを交わした(一方が送った)タイミングで
NewMatchesに表示されていたセルを削除する対応です。
期待値としましては、一方がメッセージを送ったタイミングで、双方のマッチが解除され、セルに表示されなくなることです。

コードレビューお願いいたします。
