### PR TITLE
暫定処理

### DIFF
--- a/DoryInClub/Controller/MessagesViewController.swift
+++ b/DoryInClub/Controller/MessagesViewController.swift
@@ -26,13 +26,15 @@ class MessagesViewController: UITableViewController {
     }
     
     override func viewDidLoad() {
-        configureTableView()
-        fetchConversations()
+//        configureTableView()
+//        fetchConversations()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         configureNavigationBar()
         fetchMatches()
+        fetchConversations()
+        configureTableView()
     }
     
     required init?(coder: NSCoder) {


### PR DESCRIPTION
お久しぶりです。マッチを解除した際、以下の挙動を起こしたいのですが
②の部分が、一旦ホーム画面に戻った後でないと反映されません。
**①マッチを解除（チャット画面）→　②トークが消えている状態（トークリスト画面）**

改善策として、最新の会話の取得、tableViewの生成をviewwillapperで行うようにしたのですが、改善できません。
こちらご助言お願いいたします。